### PR TITLE
LockscreenCharging: squashed (3/3)

### DIFF
--- a/res/values/pixys_configs.xml
+++ b/res/values/pixys_configs.xml
@@ -22,4 +22,7 @@
     <!-- Device specific doze package -->
     <string name="config_customDozePackage" translatable="false"></string>
 
+    <!-- Lockscreen battery info indicator  -->
+    <string name="lockscreen_battery_info_title">Lockscreen charging info</string>
+    <string name="lockscreen_battery_info_summary">Display negociated charger max current and voltage and battery temperature on lockscreen while charging</string>
 </resources>

--- a/res/xml/security_lockscreen_settings.xml
+++ b/res/xml/security_lockscreen_settings.xml
@@ -145,6 +145,11 @@
             android:summary="@string/summary_placeholder"
             settings:searchable="false"/>
 
+        <com.awaken.support.preferences.SystemSettingSwitchPreference
+            android:key="lockscreen_battery_info"
+            android:title="@string/lockscreen_battery_info_title"
+            android:summary="@string/lockscreen_battery_info_summary"
+            android:defaultValue="true" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
based on:
[1/2] Settings: show more battery info on lockscreen when charging by yank555-lu